### PR TITLE
fix: Use optional chaining when retrieving chat details

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vectara/stream-query-client",
-  "version": "0.0.1",
+  "version": "0.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@vectara/stream-query-client",
-      "version": "0.0.1",
+      "version": "0.0.4",
       "license": "Apache-2.0",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^7.4.0",

--- a/src/client.ts
+++ b/src/client.ts
@@ -130,7 +130,7 @@ export const streamQuery = async (
 };
 
 const getChat = (parsedResult: ParsedResult): Chat | null => {
-  if (!parsedResult.summary) return null;
+  if (!parsedResult.summary || !parsedResult.summary.chat) return null;
 
   return {
     conversationId: parsedResult.summary.chat.conversationId,


### PR DESCRIPTION
## CONTEXT 
When dealing with responses that have no chat property, stream data parser throws an error. In order to fix this we'll need to do an early return of null when attempting to parse non-existent chat data.

## CHANGES
- return null for chat data if the parsed response has none