### PR TITLE
Mark details type as optional.

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -14,7 +14,7 @@
     },
     "..": {
       "name": "@vectara/stream-query-client",
-      "version": "2.0.0",
+      "version": "2.0.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/jest": "^29.5.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vectara/stream-query-client",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@vectara/stream-query-client",
-      "version": "2.0.0",
+      "version": "2.0.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/jest": "^29.5.11",

--- a/src/types.ts
+++ b/src/types.ts
@@ -134,7 +134,7 @@ export type StreamUpdate = {
   isDone: boolean;
 
   // Any additional details that apply to the query response.
-  details: {
+  details?: {
     summary?: Summary;
     chat?: Chat;
     factualConsistency?: FactualConsistency;


### PR DESCRIPTION
What's weird is that it doesn't look like this should be necessary but in https://github.com/vectara/react-chatbot/pull/42 I found that `details` was occasionally undefined.