### PR TITLE
Refine API v2 client for production

### DIFF
--- a/docs/src/index.tsx
+++ b/docs/src/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import ReactDOM from "react-dom";
 import {
   streamQueryV1,
@@ -20,6 +20,7 @@ const App = () => {
   const [resultsV2, setResultsV2] = useState<string>();
   const [conversationIdV1, setConversationIdV1] = useState<string>();
   const [conversationIdV2, setConversationIdV2] = useState<string>();
+  const cancelStream = useRef<(() => void) | null>(null);
 
   const sendQueryV1 = async () => {
     const configurationOptions: ApiV1.StreamQueryConfig = {
@@ -106,7 +107,12 @@ const App = () => {
       }
     };
 
-    streamQueryV2(configurationOptions, onStreamEvent);
+    const queryStream = await streamQueryV2(
+      configurationOptions,
+      onStreamEvent
+    );
+
+    cancelStream.current = queryStream?.cancelStream ?? null;
   };
 
   return (
@@ -127,6 +133,8 @@ const App = () => {
       >
         Send
       </button>
+
+      <button onClick={() => cancelStream.current?.()}>Cancel</button>
 
       <div style={{ display: "flex" }}>
         <div style={{ flexGrow: "1", flexShrink: "1", width: "50%" }}>

--- a/src/apiV1/client.ts
+++ b/src/apiV1/client.ts
@@ -132,7 +132,9 @@ export const streamQueryV1 = async (
 
         onStreamUpdate(streamUpdate);
       });
-    } catch (error) {}
+    } catch (error) {
+      console.log(error);
+    }
   }
 };
 

--- a/src/apiV2/EventBuffer.test.ts
+++ b/src/apiV2/EventBuffer.test.ts
@@ -69,4 +69,36 @@ data:{"type":"end"}
 
     expect(onStreamEvent).toHaveBeenNthCalledWith(2, { type: "end" });
   });
+
+  test("handles unexpected errors", () => {
+    const onStreamEvent = jest.fn();
+    const buffer = new EventBuffer(onStreamEvent);
+
+    buffer.consumeChunk(`
+    {"messages":["Request failed. See https://status.vectara.com for the latest info on any outages. If the problem persists, please contact us via support or via our community forums at https://discuss.vectara.com if you’re a Growth user."],"request_id":"00000000000000000000000000000000"}
+    `);
+
+    expect(onStreamEvent).toHaveBeenCalledWith({
+      type: "unexpectedError",
+      raw: `
+      {"messages":["Request failed. See https://status.vectara.com for the latest info on any outages. If the problem persists, please contact us via support or via our community forums at https://discuss.vectara.com if you’re a Growth user."],"request_id":"00000000000000000000000000000000"}
+      `,
+    });
+  });
+
+  test("handles unexpected events", () => {
+    const onStreamEvent = jest.fn();
+    const buffer = new EventBuffer(onStreamEvent);
+
+    buffer.consumeChunk(`
+event:meteor_strike
+data:{"type":"apocalypse"}
+    `);
+
+    expect(onStreamEvent).toHaveBeenCalledWith({
+      type: "unexpectedEvent",
+      rawType: "meteor_strike",
+      raw: { type: "apocalypse" },
+    });
+  });
 });

--- a/src/apiV2/EventBuffer.ts
+++ b/src/apiV2/EventBuffer.ts
@@ -116,7 +116,19 @@ export class EventBuffer {
         break;
 
       default:
-        console.log(`Unhandled StreamQueryClient event: ${type}`, rawEvent);
+        if (!type) {
+          // Assume an error.
+          this.events.push({
+            type: "unexpectedError",
+            raw: rawEvent,
+          });
+        } else {
+          this.events.push({
+            type: "unexpectedEvent",
+            rawType: type,
+            raw: rawEvent,
+          });
+        }
     }
   }
 

--- a/src/apiV2/EventBuffer.ts
+++ b/src/apiV2/EventBuffer.ts
@@ -85,6 +85,12 @@ export class EventBuffer {
         });
         break;
 
+      case "generation_end":
+        this.events.push({
+          type: "generationEnd",
+        });
+        break;
+
       case "factual_consistency_score":
         this.events.push({
           type: "factualConsistencyScore",

--- a/src/apiV2/EventBuffer.ts
+++ b/src/apiV2/EventBuffer.ts
@@ -3,8 +3,8 @@ import { StreamEvent } from "./types";
 export class EventBuffer {
   private events: StreamEvent[];
   private onStreamEvent: (event: StreamEvent) => void;
-  private eventInProgress: string = "";
-  private updatedText: string = "";
+  private eventInProgress = "";
+  private updatedText = "";
 
   constructor(onStreamEvent: (event: any) => void) {
     this.events = [];

--- a/src/apiV2/apiTypes.ts
+++ b/src/apiV2/apiTypes.ts
@@ -1,98 +1,100 @@
 import { SummaryLanguage } from "../common/types";
 
-export type CustomerSpecificReranker = {
-  type: "customer_reranker";
-  reranker_id: string;
-};
-
-export type MmrReranker = {
-  type: "mmr";
-  diversity_bias: number;
-};
-
-export type SearchConfiguration = {
-  corpora: {
-    corpus_key: string;
-    metadata_filter?: string;
-    lexical_interpolation?: number;
-    custom_dimensions?: Record<string, number>;
-    semantics?: "default" | "query" | "response";
-  }[];
-  offset: number;
-  limit?: number;
-  context_configuration?: {
-    characters_before?: number;
-    characters_after?: number;
-    sentences_before?: number;
-    sentences_after?: number;
-    start_tag?: string;
-    end_tag?: string;
+export namespace Query {
+  export type CustomerSpecificReranker = {
+    type: "customer_reranker";
+    reranker_id: string;
   };
-  reranker?: CustomerSpecificReranker | MmrReranker;
-};
 
-export type NoneCitations = {
-  style: "none";
-};
-
-export type NumericCitations = {
-  style: "numeric";
-};
-
-export type HtmlCitations = {
-  style: "html";
-  url_pattern: string;
-  text_pattern: string;
-};
-
-export type MarkdownCitations = {
-  style: "markdown";
-  url_pattern: string;
-  text_pattern: string;
-};
-
-export type GenerationConfiguration = {
-  prompt_name?: string;
-  max_used_search_results?: number;
-  prompt_text?: string;
-  max_response_characters?: number;
-  response_language?: SummaryLanguage;
-  model_parameters?: {
-    max_tokens: number;
-    temperature: number;
-    frequency_penalty: number;
-    presence_penalty: number;
+  export type MmrReranker = {
+    type: "mmr";
+    diversity_bias: number;
   };
-  citations?:
-    | NoneCitations
-    | NumericCitations
-    | HtmlCitations
-    | MarkdownCitations;
-  enable_factual_consistency_score?: boolean;
-};
 
-export type ChatConfiguration = {
-  store?: boolean;
-  conversation_id?: string;
-};
-
-export type QueryBody = {
-  query: string;
-  search: SearchConfiguration;
-  stream_response?: boolean;
-  generation?: GenerationConfiguration;
-  chat?: ChatConfiguration;
-};
-
-export type SearchResult = {
-  document_id: string;
-  text: string;
-  score: number;
-  part_metadata: {
-    lang: string;
-    section: number;
+  export type SearchConfiguration = {
+    corpora: {
+      corpus_key: string;
+      metadata_filter?: string;
+      lexical_interpolation?: number;
+      custom_dimensions?: Record<string, number>;
+      semantics?: "default" | "query" | "response";
+    }[];
     offset: number;
-    len: number;
+    limit?: number;
+    context_configuration?: {
+      characters_before?: number;
+      characters_after?: number;
+      sentences_before?: number;
+      sentences_after?: number;
+      start_tag?: string;
+      end_tag?: string;
+    };
+    reranker?: CustomerSpecificReranker | MmrReranker;
   };
-  document_metadata: Record<string, any>;
-};
+
+  export type NoneCitations = {
+    style: "none";
+  };
+
+  export type NumericCitations = {
+    style: "numeric";
+  };
+
+  export type HtmlCitations = {
+    style: "html";
+    url_pattern: string;
+    text_pattern: string;
+  };
+
+  export type MarkdownCitations = {
+    style: "markdown";
+    url_pattern: string;
+    text_pattern: string;
+  };
+
+  export type GenerationConfiguration = {
+    prompt_name?: string;
+    max_used_search_results?: number;
+    prompt_text?: string;
+    max_response_characters?: number;
+    response_language?: SummaryLanguage;
+    model_parameters?: {
+      max_tokens: number;
+      temperature: number;
+      frequency_penalty: number;
+      presence_penalty: number;
+    };
+    citations?:
+      | NoneCitations
+      | NumericCitations
+      | HtmlCitations
+      | MarkdownCitations;
+    enable_factual_consistency_score?: boolean;
+  };
+
+  export type ChatConfiguration = {
+    store?: boolean;
+    conversation_id?: string;
+  };
+
+  export type Body = {
+    query: string;
+    search: SearchConfiguration;
+    stream_response?: boolean;
+    generation?: GenerationConfiguration;
+    chat?: ChatConfiguration;
+  };
+
+  export type SearchResult = {
+    document_id: string;
+    text: string;
+    score: number;
+    part_metadata: {
+      lang: string;
+      section: number;
+      offset: number;
+      len: number;
+    };
+    document_metadata: Record<string, any>;
+  };
+}

--- a/src/apiV2/client.test.ts
+++ b/src/apiV2/client.test.ts
@@ -25,7 +25,7 @@ describe("stream-query-client API v2", () => {
   });
 
   it("streamQuery converts streamed chunks into usable data", async () => {
-    const configurationOptions: StreamQueryConfig = {
+    const streamQueryConfig: StreamQueryConfig = {
       customerId: "1366999410",
       apiKey: "zqt_UXrBcnI2UXINZkrv4g1tQPhzj02vfdtqYJIDiA",
       corpusKey: "1",
@@ -126,6 +126,6 @@ describe("stream-query-client API v2", () => {
       }
     };
 
-    await streamQueryV2(configurationOptions, onStreamEvent);
+    await streamQueryV2({ streamQueryConfig, onStreamEvent });
   });
 });

--- a/src/apiV2/client.ts
+++ b/src/apiV2/client.ts
@@ -170,7 +170,7 @@ export const streamQueryV2 = async ({
 
     const consumeStream = async () => {
       try {
-        const buffer = new EventBuffer(onStreamEvent, includeRawEvents);
+        const buffer = new EventBuffer(onStreamEvent, includeRawEvents, status);
 
         for await (const chunk of stream) {
           try {

--- a/src/apiV2/client.ts
+++ b/src/apiV2/client.ts
@@ -51,12 +51,10 @@ const convertCitations = (citations?: GenerationConfig["citations"]) => {
 export const streamQueryV2 = async ({
   streamQueryConfig,
   onStreamEvent,
-  onError,
   includeRawEvents = false,
 }: {
   streamQueryConfig: StreamQueryConfig;
   onStreamEvent: StreamEventHandler;
-  onError?: (error: Error) => void;
   includeRawEvents?: boolean;
 }) => {
   const {
@@ -177,9 +175,12 @@ export const streamQueryV2 = async ({
             buffer.consumeChunk(chunk);
           } catch (error) {
             if (error instanceof Error) {
-              onError?.(error);
+              onStreamEvent({
+                type: "genericError",
+                error,
+              });
             } else {
-              console.log("error", error);
+              throw error;
             }
           }
         }
@@ -188,9 +189,12 @@ export const streamQueryV2 = async ({
           // Swallow the "DOMException: BodyStreamBuffer was aborted" error
           // triggered by cancelling a stream.
         } else if (error instanceof Error) {
-          onError?.(error);
+          onStreamEvent({
+            type: "genericError",
+            error,
+          });
         } else {
-          console.log("error", error);
+          throw error;
         }
       }
     };
@@ -200,9 +204,12 @@ export const streamQueryV2 = async ({
     return { cancelStream, request, status };
   } catch (error) {
     if (error instanceof Error) {
-      onError?.(error);
+      onStreamEvent({
+        type: "genericError",
+        error,
+      });
     } else {
-      console.log("error", error);
+      throw error;
     }
   }
 

--- a/src/apiV2/client.ts
+++ b/src/apiV2/client.ts
@@ -74,15 +74,7 @@ export const streamQueryV2 = async ({
       contextConfiguration,
       reranker,
     },
-    generation: {
-      promptName,
-      maxUsedSearchResults,
-      promptText,
-      maxResponseCharacters,
-      responseLanguage,
-      modelParameters,
-      citations,
-    } = {},
+    generation,
     chat,
   } = streamQueryConfig;
 
@@ -110,7 +102,21 @@ export const streamQueryV2 = async ({
       },
       reranker: convertReranker(reranker),
     },
-    generation: {
+    stream_response: true,
+  };
+
+  if (generation) {
+    const {
+      promptName,
+      maxUsedSearchResults,
+      promptText,
+      maxResponseCharacters,
+      responseLanguage,
+      modelParameters,
+      citations,
+    } = generation;
+
+    body.generation = {
       prompt_name: promptName,
       max_used_search_results: maxUsedSearchResults,
       prompt_text: promptText,
@@ -123,12 +129,14 @@ export const streamQueryV2 = async ({
         presence_penalty: modelParameters.presencePenalty,
       },
       citations: convertCitations(citations),
-    },
-    chat: chat && {
+    };
+  }
+
+  if (chat) {
+    body.chat = {
       store: chat.store,
-    },
-    stream_response: true,
-  };
+    };
+  }
 
   let path;
 

--- a/src/apiV2/client.ts
+++ b/src/apiV2/client.ts
@@ -79,7 +79,7 @@ export const streamQueryV2 = async (
     chat,
   } = config;
 
-  let body: Query.Body = {
+  const body: Query.Body = {
     query,
     search: {
       corpora: [
@@ -152,7 +152,7 @@ export const streamQueryV2 = async (
       url
     );
 
-    new Promise(async (resolve, reject) => {
+    const consumeStream = async () => {
       try {
         const buffer = new EventBuffer(onStreamEvent);
 
@@ -163,12 +163,17 @@ export const streamQueryV2 = async (
             console.log("error", error);
           }
         }
-
-        resolve(undefined);
       } catch (error) {
-        reject(error);
+        if (error instanceof DOMException && error.name == "AbortError") {
+          // Swallow the "DOMException: BodyStreamBuffer was aborted" error
+          // triggered by cancelling a stream.
+        } else {
+          console.log("error", error);
+        }
       }
-    });
+    };
+
+    consumeStream();
 
     return { cancelStream };
   } catch (error) {

--- a/src/apiV2/client.ts
+++ b/src/apiV2/client.ts
@@ -3,7 +3,7 @@ import {
   StreamQueryConfig,
   StreamEventHandler,
 } from "./types";
-import { QueryBody } from "./apiTypes";
+import { Query } from "./apiTypes";
 import { DEFAULT_DOMAIN } from "../common/constants";
 import { generateStream } from "../common/generateStream";
 import { EventBuffer } from "./EventBuffer";
@@ -53,7 +53,8 @@ export const streamQueryV2 = async (
   const {
     customerId,
     apiKey,
-    endpoint,
+    authToken,
+    domain,
     corpusKey,
     query,
     search: {
@@ -78,7 +79,7 @@ export const streamQueryV2 = async (
     chat,
   } = config;
 
-  let body: QueryBody = {
+  let body: Query.Body = {
     query,
     search: {
       corpora: [
@@ -134,13 +135,15 @@ export const streamQueryV2 = async (
     }
   }
 
-  const headers = {
-    "x-api-key": apiKey,
+  const headers: any = {
     "customer-id": customerId,
     "Content-Type": "application/json",
   };
 
-  const url = `${endpoint ?? DEFAULT_DOMAIN}${path}`;
+  if (apiKey) headers["x-api-key"] = apiKey;
+  if (authToken) headers["Authorization"] = `Bearer ${authToken}`;
+
+  const url = `${domain ?? DEFAULT_DOMAIN}${path}`;
 
   try {
     const { cancelStream, stream } = await generateStream(

--- a/src/apiV2/client.ts
+++ b/src/apiV2/client.ts
@@ -114,6 +114,7 @@ export const streamQueryV2 = async ({
       responseLanguage,
       modelParameters,
       citations,
+      enableFactualConsistencyScore,
     } = generation;
 
     body.generation = {
@@ -129,6 +130,7 @@ export const streamQueryV2 = async ({
         presence_penalty: modelParameters.presencePenalty,
       },
       citations: convertCitations(citations),
+      enable_factual_consistency_score: enableFactualConsistencyScore,
     };
   }
 

--- a/src/apiV2/client.ts
+++ b/src/apiV2/client.ts
@@ -52,12 +52,12 @@ export const streamQueryV2 = async ({
   streamQueryConfig,
   onStreamEvent,
   onError,
-  includeRawEvents,
+  includeRawEvents = false,
 }: {
   streamQueryConfig: StreamQueryConfig;
   onStreamEvent: StreamEventHandler;
-  onError: (error: Error) => void;
-  includeRawEvents: boolean;
+  onError?: (error: Error) => void;
+  includeRawEvents?: boolean;
 }) => {
   const {
     customerId,
@@ -162,7 +162,7 @@ export const streamQueryV2 = async ({
   };
 
   try {
-    const { cancelStream, stream } = await generateStream(
+    const { cancelStream, stream, status } = await generateStream(
       headers,
       JSON.stringify(body),
       url
@@ -177,7 +177,7 @@ export const streamQueryV2 = async ({
             buffer.consumeChunk(chunk);
           } catch (error) {
             if (error instanceof Error) {
-              onError(error);
+              onError?.(error);
             } else {
               console.log("error", error);
             }
@@ -188,7 +188,7 @@ export const streamQueryV2 = async ({
           // Swallow the "DOMException: BodyStreamBuffer was aborted" error
           // triggered by cancelling a stream.
         } else if (error instanceof Error) {
-          onError(error);
+          onError?.(error);
         } else {
           console.log("error", error);
         }
@@ -197,10 +197,10 @@ export const streamQueryV2 = async ({
 
     consumeStream();
 
-    return { cancelStream, request };
+    return { cancelStream, request, status };
   } catch (error) {
     if (error instanceof Error) {
-      onError(error);
+      onError?.(error);
     } else {
       console.log("error", error);
     }

--- a/src/apiV2/types.ts
+++ b/src/apiV2/types.ts
@@ -95,6 +95,20 @@ export type StreamQueryConfig = {
   };
 };
 
+export type StreamQueryRequestHeaders = {
+  ["customer-id"]: string;
+  ["Content-Type"]: string;
+  ["x-api-key"]?: string;
+  ["Authorization"]?: string;
+};
+
+export type StreamQueryRequest = {
+  method: string;
+  url: string;
+  headers: StreamQueryRequestHeaders;
+  body: Query.Body;
+};
+
 export type StreamEvent =
   | ErrorEvent
   | SearchResultsEvent
@@ -104,38 +118,42 @@ export type StreamEvent =
   | FactualConsistencyScoreEvent
   | EndEvent;
 
-export type ErrorEvent = {
+type BaseEvent = {
+  raw?: any;
+};
+
+export type ErrorEvent = BaseEvent & {
   type: "error";
   messages: string[];
 };
 
-export type SearchResultsEvent = {
+export type SearchResultsEvent = BaseEvent & {
   type: "searchResults";
   searchResults: Query.SearchResult[];
 };
 
-export type ChatInfoEvent = {
+export type ChatInfoEvent = BaseEvent & {
   type: "chatInfo";
   chatId: string;
   turnId: string;
 };
 
-export type GenerationChunkEvent = {
+export type GenerationChunkEvent = BaseEvent & {
   type: "generationChunk";
   updatedText: string;
   generationChunk: string;
 };
 
-export type GenerationEndEvent = {
+export type GenerationEndEvent = BaseEvent & {
   type: "generationEnd";
 };
 
-export type FactualConsistencyScoreEvent = {
+export type FactualConsistencyScoreEvent = BaseEvent & {
   type: "factualConsistencyScore";
   factualConsistencyScore: number;
 };
 
-export type EndEvent = {
+export type EndEvent = BaseEvent & {
   type: "end";
 };
 

--- a/src/apiV2/types.ts
+++ b/src/apiV2/types.ts
@@ -64,10 +64,10 @@ export type StreamQueryConfig = {
     contextConfiguration?: {
       charactersBefore?: number;
       charactersAfter?: number;
-      // For summary references, this is the number of sentences to include before/after
+      // For summary references, this is the number of sentences to include before
       // relevant reference snippets.
       sentencesBefore?: number;
-      // For summary references, this is the number of sentences to include before/after
+      // For summary references, this is the number of sentences to include after
       // relevant reference snippets.
       sentencesAfter?: number;
       startTag?: string;

--- a/src/apiV2/types.ts
+++ b/src/apiV2/types.ts
@@ -117,8 +117,9 @@ export type StreamEvent =
   | GenerationEndEvent
   | FactualConsistencyScoreEvent
   | EndEvent
-  | UnexpectedErrorEvent
-  | UnexpectedEvent;
+  | UnexpectedEvent
+  | RequestErrorEvent
+  | UnexpectedErrorEvent;
 
 type BaseEvent = {
   raw?: any;
@@ -159,14 +160,20 @@ export type EndEvent = BaseEvent & {
   type: "end";
 };
 
-export type UnexpectedErrorEvent = {
-  type: "unexpectedError";
-  raw: any;
-};
-
 export type UnexpectedEvent = {
   type: "unexpectedEvent";
   rawType: string;
+  raw: any;
+};
+
+export type RequestErrorEvent = {
+  type: "requestError";
+  status: number;
+  raw: any;
+};
+
+export type UnexpectedErrorEvent = {
+  type: "unexpectedError";
   raw: any;
 };
 

--- a/src/apiV2/types.ts
+++ b/src/apiV2/types.ts
@@ -116,7 +116,9 @@ export type StreamEvent =
   | GenerationChunkEvent
   | GenerationEndEvent
   | FactualConsistencyScoreEvent
-  | EndEvent;
+  | EndEvent
+  | UnexpectedErrorEvent
+  | UnexpectedEvent;
 
 type BaseEvent = {
   raw?: any;
@@ -155,6 +157,17 @@ export type FactualConsistencyScoreEvent = BaseEvent & {
 
 export type EndEvent = BaseEvent & {
   type: "end";
+};
+
+export type UnexpectedErrorEvent = {
+  type: "unexpectedError";
+  raw: any;
+};
+
+export type UnexpectedEvent = {
+  type: "unexpectedEvent";
+  rawType: string;
+  raw: any;
 };
 
 export type StreamEventHandler = (event: StreamEvent) => void;

--- a/src/apiV2/types.ts
+++ b/src/apiV2/types.ts
@@ -119,6 +119,7 @@ export type StreamEvent =
   | EndEvent
   | UnexpectedEvent
   | RequestErrorEvent
+  | GenericErrorEvent
   | UnexpectedErrorEvent;
 
 type BaseEvent = {
@@ -170,6 +171,11 @@ export type RequestErrorEvent = {
   type: "requestError";
   status: number;
   raw: any;
+};
+
+export type GenericErrorEvent = {
+  type: "genericError";
+  error: Error;
 };
 
 export type UnexpectedErrorEvent = {

--- a/src/apiV2/types.ts
+++ b/src/apiV2/types.ts
@@ -1,5 +1,7 @@
 import { SummaryLanguage } from "../common/types";
-import { SearchResult } from "./apiTypes";
+import { Query } from "./apiTypes";
+
+export type { Query } from "./apiTypes";
 
 export type GenerationConfig = {
   // The preferred prompt to use, if applicable
@@ -34,11 +36,15 @@ export type StreamQueryConfig = {
   customerId: string;
 
   // The Vectara query API key that has access to the corpora you're querying.
-  apiKey: string;
+  apiKey?: string;
 
-  // An optional endpoint to send the query to.
-  // Used if proxying the Vectara API URL behind a custom server.
-  endpoint?: string;
+  // Alternatively specify the JWT token to use for authentication.
+  authToken?: string;
+
+  // An optional domain to send the query to. Useful for proxying API requests.
+  // Expects specific endpoints to be available at <domain>/v2/query,
+  // <domain>/v2/chats/:chatId/turns, and <domain>/v2/chats
+  domain?: string;
 
   // The query to send to the API. This is the user input.
   query: string;
@@ -89,37 +95,23 @@ export type StreamQueryConfig = {
   };
 };
 
-export type Summary = {
-  prompt?: string;
-};
-
-export type Chat = {
-  conversationId: string;
-  turnId: string;
-  // Debug-only
-  rephrasedQuery?: string;
-};
-
-export type FactualConsistency = {
-  score: number;
-};
-
 export type StreamEvent =
   | ErrorEvent
   | SearchResultsEvent
   | ChatInfoEvent
   | GenerationChunkEvent
+  | GenerationEndEvent
   | FactualConsistencyScoreEvent
   | EndEvent;
 
 export type ErrorEvent = {
   type: "error";
-  messages?: string[];
+  messages: string[];
 };
 
 export type SearchResultsEvent = {
   type: "searchResults";
-  searchResults: SearchResult[];
+  searchResults: Query.SearchResult[];
 };
 
 export type ChatInfoEvent = {
@@ -134,6 +126,10 @@ export type GenerationChunkEvent = {
   generationChunk: string;
 };
 
+export type GenerationEndEvent = {
+  type: "generationEnd";
+};
+
 export type FactualConsistencyScoreEvent = {
   type: "factualConsistencyScore";
   factualConsistencyScore: number;
@@ -144,8 +140,3 @@ export type EndEvent = {
 };
 
 export type StreamEventHandler = (event: StreamEvent) => void;
-
-export type DocMetadata = {
-  name: string;
-  value: string;
-};

--- a/src/common/generateStream.ts
+++ b/src/common/generateStream.ts
@@ -3,7 +3,7 @@ export const generateStream = async (
   body: string,
   url: string
 ) => {
-  let controller = new AbortController();
+  const controller = new AbortController();
 
   const response = await fetch(url, {
     method: "POST",

--- a/src/common/generateStream.ts
+++ b/src/common/generateStream.ts
@@ -12,12 +12,12 @@ export const generateStream = async (
     signal: controller.signal,
   });
 
-  if (response.status !== 200) throw new Error(response.status.toString());
   if (!response.body) throw new Error("Response body does not exist");
 
   return {
     stream: getIterableStream(response.body),
     cancelStream: () => controller.abort(),
+    status: response.status,
   };
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,11 @@
 // Creates namespace "ApiV1"
 import * as ApiV1 from "./apiV1/types";
-export { ApiV1 };
-
-export { streamQueryV1 } from "./apiV1/client";
 
 // Creates namespace "ApiV2"
 import * as ApiV2 from "./apiV2/types";
-export { ApiV2 };
 
+export { ApiV1 };
+export { streamQueryV1 } from "./apiV1/client";
+
+export { ApiV2 };
 export { streamQueryV2 } from "./apiV2/client";


### PR DESCRIPTION
## Internal changes

* Cleaned up types.
* The code that is emitted when the consumer cancels the stream is now swallowed.
* Refactored code that was misusing Promise.

## Consumer-facing changes
* Added `authToken` config option.
* Renamed `endpoint` -> `domain`.
* Exported API types under `Query` namespace.
* New `GenerationEndEvent` is emitted to signify when the generated response is complete.
* New `UnexpectedEvent` surfaces any stream events that were unexpected. This provides future-proofing against stream events that might be added to the API in the future.
* New `RequestErrorEvent` (server responds with non-200), `GenericErrorEvent` (when the buffer logic throws a JS error, which shouldn't happen), and `UnexpectedErrorEvent` (catch-all for other error cases) surface additional error cases.