### PR TITLE
chore: Add build configs and docs files to npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,5 @@
 src/
+docs/
 node_modules/
 images/
 
@@ -6,3 +7,7 @@ images/
 build.js
 tsconfig.json
 tsconfig.tsbuildinfo
+.eslintrc.js
+.prettierrc.json
+jest.config.js
+buildConfig.js


### PR DESCRIPTION
## CONTEXT
Adding unnecessary files to npmignore can signficantly reduce package size.

## CHANGES
- remove docs from npm package
- remove build configs from npm package

## SCREENSHOTS

### BEFORE
<img width="474" alt="Screenshot 2024-08-23 at 9 47 53 AM" src="https://github.com/user-attachments/assets/d59c2d84-50c2-4e7b-865d-c50abed45de4">

### AFTER
<img width="470" alt="Screenshot 2024-08-23 at 9 48 02 AM" src="https://github.com/user-attachments/assets/a93511e9-5a33-499e-9d80-7338a6c4e406">

