### PR TITLE
feat: Accept a requestSource to allow tracking the request on the back end

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -14,7 +14,7 @@
     },
     "..": {
       "name": "@vectara/stream-query-client",
-      "version": "4.3.0",
+      "version": "5.0.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/jest": "^29.5.11",

--- a/docs/src/index.tsx
+++ b/docs/src/index.tsx
@@ -38,7 +38,6 @@ const App = () => {
     };
 
     const onStreamUpdate = (update: ApiV1.StreamUpdate) => {
-      // console.log("v1", update);
       const { updatedText, details, references } = update;
 
       if (details?.chat) {
@@ -107,7 +106,8 @@ const App = () => {
 
     const queryStream = await streamQueryV2({
       streamQueryConfig,
-      onStreamEvent
+      onStreamEvent,
+      requestSource: "stream-query-docs"
     });
 
     cancelStream.current = queryStream?.cancelStream ?? null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vectara/stream-query-client",
-  "version": "4.3.0",
+  "version": "5.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@vectara/stream-query-client",
-      "version": "4.3.0",
+      "version": "5.0.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/jest": "^29.5.11",

--- a/src/apiV2/client.ts
+++ b/src/apiV2/client.ts
@@ -64,11 +64,13 @@ const convertCitations = (citations?: GenerationConfig["citations"]) => {
 export const streamQueryV2 = async ({
   streamQueryConfig,
   onStreamEvent,
-  includeRawEvents = false
+  includeRawEvents = false,
+  requestSource
 }: {
   streamQueryConfig: StreamQueryConfig;
   onStreamEvent: StreamEventHandler;
   includeRawEvents?: boolean;
+  requestSource?: string;
 }) => {
   const {
     customerId,
@@ -170,6 +172,7 @@ export const streamQueryV2 = async ({
 
   if (apiKey) headers["x-api-key"] = apiKey;
   if (authToken) headers["Authorization"] = `Bearer ${authToken}`;
+  if (requestSource) headers["x-source"] = requestSource;
 
   const url = `${domain ?? DEFAULT_DOMAIN}${path}`;
 

--- a/src/apiV2/types.ts
+++ b/src/apiV2/types.ts
@@ -115,6 +115,7 @@ export type StreamQueryRequestHeaders = {
   ["Content-Type"]: string;
   ["x-api-key"]?: string;
   ["Authorization"]?: string;
+  ["x-source"]?: string;
 };
 
 export type StreamQueryRequest = {


### PR DESCRIPTION
This change allows the consumer of StreamQueryV2 to pass in an optional requestSource to allow the backend to track where a query request is coming from.